### PR TITLE
change category to TV_SET_TOP_BOX

### DIFF
--- a/index.js
+++ b/index.js
@@ -174,7 +174,7 @@ class xboxTvDevice {
 		const accessoryName = this.name;
 		const accessoryUUID = UUID.generate(accessoryName);
 		this.accessory = new Accessory(accessoryName, accessoryUUID);
-		this.accessory.category = Categories.TELEVISION;
+		this.accessory.category = Categories.TV_SET_TOP_BOX;
 
 		this.accessory.getService(Service.AccessoryInformation)
 			.setCharacteristic(Characteristic.Manufacturer, this.manufacturer)


### PR DESCRIPTION
This is an iOS 14 Category.  It will make people's rooms look much nicer.  No longer more than 1 TV in there.  The icons for Xbox One will look like this:

![IMG_3237](https://user-images.githubusercontent.com/1437332/93282278-e5b6e800-f782-11ea-97cd-7a572c520ac6.jpg)
![IMG_3238](https://user-images.githubusercontent.com/1437332/93282285-e64f7e80-f782-11ea-9894-786bfa564ec8.jpg)
