### PR TITLE
Fix migration issues from 1.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -377,30 +377,29 @@ class xboxTvDevice {
 		this.prepareAccessory();
 	}
 
-	async prepareDirectoryAndFiles() {
+	prepareDirectoryAndFiles() {
 		this.log.debug('Device: %s %s, prepare directory and files.', this.host, this.name);
 
 		try {
 			//check if the directory exists, if not then create it
 			if (fs.existsSync(this.prefDir) == false) {
-				await fsPromises.mkdir(this.prefDir);
+				fs.mkdirSync(this.prefDir);
 			}
 			if (fs.existsSync(this.authTokenFile) == false) {
-				await fsPromises.writeFile(this.authTokenFile, '');
+				fs.writeFileSync(this.authTokenFile, '');
 			}
 			if (fs.existsSync(this.devInfoFile) == false) {
-				await fsPromises.writeFile(this.devInfoFile, '');
+				fs.writeFileSync(this.devInfoFile, '');
 			}
 			if (fs.existsSync(this.inputsFile) == false) {
-				await fsPromises.writeFile(this.inputsFile, '');
+				fs.writeFileSync(this.inputsFile, '');
 			}
 			if (fs.existsSync(this.inputsNamesFile) == false) {
-				await fsPromises.writeFile(this.inputsNamesFile, '');
+				fs.writeFileSync(this.inputsNamesFile, '');
 			}
 			if (fs.existsSync(this.inputsTargetVisibilityFile) == false) {
-				await fsPromises.writeFile(this.inputsTargetVisibilityFile, '');
+				fs.writeFileSync(this.inputsTargetVisibilityFile, '');
 			}
-
 		} catch (error) {
 			this.log.error('Device: %s %s, prepare directory and files error: %s', this.host, this.name, error);
 		};
@@ -1083,7 +1082,7 @@ class xboxTvDevice {
 			//get input oneStoreProductId
 			const inputOneStoreProductId = (inputs[j].oneStoreProductId != undefined) ? inputs[j].oneStoreProductId : undefined;
 
-			//get input name		
+			//get input name
 			const inputName = (savedInputsNames[inputTitleId] != undefined) ? savedInputsNames[inputTitleId] : (savedInputsNames[inputReference] != undefined) ? savedInputsNames[inputReference] : (savedInputsNames[inputOneStoreProductId] != undefined) ? savedInputsNames[inputOneStoreProductId] : inputs[j].name;
 
 			//get input type


### PR DESCRIPTION
The 2.0.0 release changed the spelling of `xboxliveid` to `xboxLiveId`. This caused the empty string `''` to be used instead, causing the same UUID for all Xboxes where `xboxliveid` was defined but `xboxLiveId` was not. The plug-in now throws an error if either required field `xboxLiveId` or `host` is not configured, and allows the old spelling `xboxliveid` for backward compatibility.

I also fixed an issue caused by invoking `async` method `prepareDirectoryAndFiles` without waiting for it to complete. When creating the files for a new accessory (or after deleting/renaming the `xboxTv` directory), the files were not guaranteed to exist before they were read. Unfortunately, it is not possible to `await` it in a `class constructor`, so I changed the `fs` calls to their `Sync` variants.

This fixes the issues I reported in #124.
