### PR TITLE
Take substring of game names

### DIFF
--- a/src/xboxdevice.js
+++ b/src/xboxdevice.js
@@ -806,7 +806,7 @@ class XboxDevice extends EventEmitter {
                     const inputService = accessory.addService(Service.InputSource, inputName, `Input ${inputIdentifier}`);
                     inputService
                         .setCharacteristic(Characteristic.Identifier, inputIdentifier)
-                        .setCharacteristic(Characteristic.Name, inputName.substring(0,63))
+                        .setCharacteristic(Characteristic.Name, inputName.substring(0, 64))
                         .setCharacteristic(Characteristic.InputSourceType, inputSourceType)
                         .setCharacteristic(Characteristic.IsConfigured, isConfigured)
                         .setCharacteristic(Characteristic.CurrentVisibilityState, currentVisibility)

--- a/src/xboxdevice.js
+++ b/src/xboxdevice.js
@@ -806,7 +806,7 @@ class XboxDevice extends EventEmitter {
                     const inputService = accessory.addService(Service.InputSource, inputName, `Input ${inputIdentifier}`);
                     inputService
                         .setCharacteristic(Characteristic.Identifier, inputIdentifier)
-                        .setCharacteristic(Characteristic.Name, inputName)
+                        .setCharacteristic(Characteristic.Name, inputName.substring(0,63))
                         .setCharacteristic(Characteristic.InputSourceType, inputSourceType)
                         .setCharacteristic(Characteristic.IsConfigured, isConfigured)
                         .setCharacteristic(Characteristic.CurrentVisibilityState, currentVisibility)


### PR DESCRIPTION
The plugin issues warnings for names that are too long (and I suspect this may be breaking things elsewhere). Dragon Age 11 definitive edition exceeds the limit, so I am unable to use the api.