### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@v8
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/grzegorz914/homebridge-xbox-tv/security/code-scanning/1](https://github.com/grzegorz914/homebridge-xbox-tv/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions` block for the workflow or for the specific job, granting only the scopes needed by `actions/stale`. This prevents the job from inheriting potentially overbroad default `GITHUB_TOKEN` permissions from the repository/organization, and documents the intended access.

The best minimal fix without changing functionality is to add a `permissions` block at the job level for `stale`, because that is the only job in this workflow and is the one that needs write access. `actions/stale` needs to read and write issues and pull requests, and it may also require `contents: read` for repository metadata; we can follow the CodeQL suggestion for a minimal write set: `contents: write`, `issues: write`, `pull-requests: write`. To implement this, edit `.github/workflows/stale.yml` and insert a `permissions:` mapping under `jobs: stale:` at the same indentation level as `runs-on:` (line 10). No imports or other methods are needed since this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
